### PR TITLE
Make tutorial more prominent

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -307,13 +307,14 @@
             <div class="get-started-card4 col-lg" >
                <div class="card-body d-flex flex-column">
                   <h5 class="card-title" style="margin-top: 10px; font-weight: 600;">4. Fire it all up</h5>
-                  <p class="card-text text-muted">Start Label Sleuth</p>
+                  <p class="card-text text-muted">For a quick start, follow our tutorial <span style="font-style: italic;">(recommended)</span></p>
+                  <p class="card-text text-muted">
+                     <a class="reference external" href="docs/tutorial.html">View tutorial</a>  
+                  </p>
+                  <p class="card-text text-muted">To skip the tutorial, start Label Sleuth</p>
                   <p class="code-block"><code>python -m label_sleuth.start_label_sleuth</code></p>
                   <p class="card-text text-muted">Access Label Sleuth on your browser</p>
                   <a class="reference external" href="http://localhost:8000/">http://localhost:8000/</a>
-                  <p class="card-text text-muted" style="margin-top: 20px;">For a quick start, check out our tutorial
-                  </p>
-                  <a class="reference external" href="docs/tutorial.html">View tutorial</a>
                </div>
             </div>
          </div>

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -49,11 +49,17 @@ Recommended procedure to install Label Sleuth:
    python -m label_sleuth.start_label_sleuth --load_sample_corpus wiki_animals_2000_pages
    ```
    
-   This command also pre-loads a collection of Wikipedia documents for demonstration purposes.
+   This command also pre-loads a collection of Wikipedia documents that will be used in the tutorial below.
    
    Access Label Sleuth on your browser by navigating to the following page:
 
    [http://localhost:8000/](http://localhost:8000/)
+
+5. **Follow tutorial** (Recommended)
+
+   Now that you have installed Label Sleuth, we strongly recommend following our step-by-step tutorial to get acquainted with the system.
+
+   [View tutorial](tutorial.md)
 
 :::
 
@@ -74,7 +80,3 @@ When starting up Label Sleuth, the project directory and port can be customized 
 - ```--host <ip_or_name>```:
    - Set host to ```<ip_or_name>``` (default is localhost, use 0.0.0.0 to expose the service to external communication)
 :::
-
-## Next steps
-
-Now that you have installed Label Sleuth, check out our quick system [tutorial](tutorial.md). 

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -3,12 +3,27 @@
 New to Label Sleuth? We suggest following this quick tutorial to try it out. In this tutorial, you will use Label Sleuth to create a model that identifies sentences describing animal habitats in the sample dataset from Wikipedia.    
 
 :::{note}
-Before proceeding, make sure that you have already installed Label Sleuth, following our [installation instructions](installation.md), and that you loaded the sample dataset at startup.
+Before proceeding, make sure that you have already installed Label Sleuth, following our [installation instructions](installation.md).
 :::
 
 ## Steps
 
-### (1) Create new workspace
+### (1) Start Label Sleuth
+
+If Label Sleuth is not already running (or you have not instructed it to load the sample dataset at startup), invoke it with the following command:
+
+```
+python -m label_sleuth.start_label_sleuth --load_sample_corpus wiki_animals_2000_pages
+```
+
+This starts the system and pre-loads a set of Wikipedia documents to use in the rest of the tutorial.
+
+Once started, access Label Sleuth on your browser by navigating to the following page:
+
+[http://localhost:8000/](http://localhost:8000/)
+
+
+### (2) Create new workspace
 
 ::::{grid} 2
 :padding: 4
@@ -33,7 +48,7 @@ _**How:** To create a workspace, enter your preferred name and select the pre-lo
 
 ::::
 
-### (2) Create new category
+### (3) Create new category
 
 ::::{grid} 2
 :padding: 4
@@ -58,13 +73,12 @@ _**How:** To create a category, click the `+` icon at the top of the screen. In 
 
 ::::
 
-### (3) Start annotating
+### (4) Start annotating
 
 You are now ready to start annotating sentences as positive or negative w.r.t. the category you have created. For example, the following sentence is a positive example for the Habitat category:
 
 ```text
-The Komodo dragon is endemic to the Indonesian islands of
-Komodo, Rinca, Flores, and Gili Motang
+The Komodo dragon is endemic to the Indonesian islands of Komodo, Rinca, Flores, and Gili Motang
 ```
 
 Focus more on annotating _positive_ examples (i.e., sentences that describe the habitat), as they are much more valuable for the AI model. There are initially two ways to identify elements to annotate:
@@ -121,7 +135,7 @@ _**How:** If not already shown, bring up the search panel by clicking on the mag
 
 ::::
 
-### (4) Continue annotating
+### (5) Continue annotating
 
 ::::{grid} 2
 :padding: 4
@@ -147,7 +161,7 @@ _**How:** Keep annotating as usual. Check the progress bar on the left for annot
 
 ::::
 
-### (5) Receive annotation guidance
+### (6) Receive annotation guidance
 
 ::::{grid} 2
 :padding: 4
@@ -173,7 +187,7 @@ _**How:** If not shown, bring up the recommendation panel by clicking on the `La
 
 ::::
 
-### (6) Check the AI model's predictions
+### (7) Check the AI model's predictions
 
 ::::{grid} 2
 :padding: 4
@@ -199,12 +213,12 @@ _**How:** If not shown, bring up the list of all positive predictions of the AI 
 
 ::::
 
-### (7) Keep going
+### (8) Keep going
 
 Keep annotating. Occasionally, a new version of the AI model is created to provide better guidance of next elements to annotate and to better identify positive sentences.
 Spend 30 mins with Label Sleuth. Does the AI model get better in finding positive sentences for your target category?
 
 
-### (8) Great job!
+### (9) Great job!
 
 You have mastered the basics of Label Sleuth! You are now ready to use it to create classification models for your own use cases.


### PR DESCRIPTION
This PR addresses a complaint that the tutorial can be easy to miss by readers following the installation instructions. To address this issue, this PR makes the following changes:

- Change installation instructions on the [homepage](https://github.com/label-sleuth/label-sleuth.org/blob/f6e8f7f354cd898a3d912b077ac67e5c1ee312f5/docs/_templates/index.html) to put the step of opening the tutorial before the step of starting the system (as we have seen that if someone starts the system, they may forget to come back and follow the step to view the tutorial) 
- Change [tutorial page](https://github.com/label-sleuth/label-sleuth.org/blob/f6e8f7f354cd898a3d912b077ac67e5c1ee312f5/docs/docs/tutorial.md) to also include instructions on how to start the system as the first step. This enables the flow outlined in the first step, where one starts the tutorial before having seen the instructions on how to start the system.
- Change the detailed installation instructions on the [installation page](https://github.com/label-sleuth/label-sleuth.org/blob/f6e8f7f354cd898a3d912b077ac67e5c1ee312f5/docs/docs/installation.md) to include the tutorial as a recommended last step (in contrast to it only appearing under the next step section, which was easier to miss). 