### PR TITLE
Allow text wrapping in pre tags

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -20,6 +20,10 @@ body{
   display: block;
 } 
 
+span.pre, pre {
+  white-space: pre-wrap;
+}
+
 /* Override theme's background color and font color for nav bar */
 .bd-header.navbar-light#navbar-main {
   background-color: black !important;


### PR DESCRIPTION
This PR allows wrapping of text appearing in pre tags. This allows documentation pages with long text inside pre tags (such as the installation and tutorial page) to adjust to small screen sizes without horizontal scroll bars appearing.