### PR TITLE
Update import_label API to reflect category_id refactor

### DIFF
--- a/docs/docs/dev/api.md
+++ b/docs/docs/dev/api.md
@@ -475,7 +475,7 @@ Stream of a csv file
 {
     "categories": [
         {
-            "category": "category1",
+            "category_id": "3",
             "counter": 30
         }
     ],


### PR DESCRIPTION
This PR updates the documentation of the `import_label` API endpoint to reflect the replacement of the `category_name` attribute by the `category_id` attribute in the endpoint's response, which happened as part of [this commit](https://github.com/label-sleuth/label-sleuth/commit/1592103c119d14e9a0687fff1791df49a3fd5968).