### PR TITLE
Add href link to the project's GitHub logo.

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -309,7 +309,7 @@
                   <h5 class="card-title" style="margin-top: 10px; font-weight: 600;">4. Fire it all up</h5>
                   <p class="card-text text-muted">For a quick start, follow our tutorial <span style="font-style: italic;">(recommended)</span></p>
                   <p class="card-text text-muted">
-                     <a class="reference external" href="docs/tutorial.html">View tutorial</a>  
+                     <a class="reference external" href="docs/tutorial.html">View tutorial</a>
                   </p>
                   <p class="card-text text-muted">To skip the tutorial, start Label Sleuth</p>
                   <p class="code-block"><code>python -m label_sleuth.start_label_sleuth</code></p>
@@ -348,7 +348,9 @@
 <div class="row about-project-text">
    <div class="col text-center">
       <p>Label Sleuth is an open source project initiated by IBM Research in collaboration with leading universities</p>
-      <img src="_static/images/homepage/ibm_research.svg" alt="IBM Research">
+      <a href="https://github.com/label-sleuth">
+        <img src="_static/images/homepage/ibm_research.svg" alt="IBM Research">
+      </a>
    </div>
 </div>
 </div>

--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -348,7 +348,7 @@
 <div class="row about-project-text">
    <div class="col text-center">
       <p>Label Sleuth is an open source project initiated by IBM Research in collaboration with leading universities</p>
-      <a href="https://github.com/label-sleuth">
+      <a href="https://github.com/label-sleuth/label-sleuth">
         <img src="_static/images/homepage/ibm_research.svg" alt="IBM Research">
       </a>
    </div>


### PR DESCRIPTION
At the bottom of the homepage, there's a GitHub project logo, but it wan't linked to anything. So, I linked it with Label Sleuth's repository page https://github.com/label-sleuth/label-sleuth


        Developer's Certificate of Origin 1.1

        By making a contribution to this project, I certify that:

        (a) The contribution was created in whole or in part by me and I
            have the right to submit it under the open source license
            indicated in the file; or

        (b) The contribution is based upon previous work that, to the best
            of my knowledge, is covered under an appropriate open source
            license and I have the right under that license to submit that
            work with modifications, whether created in whole or in part
            by me, under the same open source license (unless I am
            permitted to submit under a different license), as indicated
            in the file; or

        (c) The contribution was provided directly to me by some other
            person who certified (a), (b) or (c) and I have not modified
            it.

        (d) I understand and agree that this project and the contribution
            are public and that a record of the contribution (including all
            personal information I submit with it, including my sign-off) is
            maintained indefinitely and may be redistributed consistent with
            this project or the open source license(s) involved.