### PR TITLE
Create substitution for slack link

### DIFF
--- a/docs/community_overview.md
+++ b/docs/community_overview.md
@@ -18,7 +18,7 @@ Follow the links below to learn more about the Label Sleuth community.
 :columns: 12 6 4 4
 :margin: 0 3 0 0
 
-Reach out to us on [Slack](https://join.slack.com/t/labelsleuth/shared_invite/zt-1j5tpz1jl-W~UaNEKmK0RtzK~lI3Wkxg)
+Reach out to us on {{ '[Slack]({})'.format(slack_link) }} 
 
 :::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
    'sphinx_togglebutton'
 ]
 
-myst_enable_extensions = ["colon_fence"]
+myst_enable_extensions = ["colon_fence", "substitution"]
 
 # Add no prefix to resource URLs for 404 page
 notfound_urls_prefix = ''
@@ -122,6 +122,10 @@ html_sidebars = {
 }
 
 html_additional_pages = {'index': 'index.html'}
+
+myst_substitutions = {
+  "slack_link": "https://join.slack.com/t/labelsleuth/shared_invite/zt-1j5tpz1jl-W~UaNEKmK0RtzK~lI3Wkxg"
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -39,6 +39,6 @@ At the moment the system does not natively support building multi-class models. 
 
 :::{admonition} Have more questions?
 
-Reach out to us on <span>&nbsp;</span> [![Slack](https://img.shields.io/badge/Slack-darkgreen?logo=slack&logoColor=white)](https://join.slack.com/t/labelsleuth/shared_invite/zt-1h1exje12-wuSTcktxUVHefZgAZ9bEiQ)
+Reach out to us on <span>&nbsp;</span> {{ '[![Slack](https://img.shields.io/badge/Slack-darkgreen?logo=slack&logoColor=white)]({})'.format(slack_link) }}
 :::
 


### PR DESCRIPTION
Currently, whenever the invitation link to Label Sleuth's slack workspace changes, one has to find all places where the link appears on the website and edit them. This creates the potential for missing some of the link's instances, which can lead to out-of-date links.

To address this issue and simplify the maintenance of the slack link, this PR adds a `slack_link` substitution holding the link to the slack workspace to the [conf.py](https://github.com/label-sleuth/label-sleuth.org/blob/main/docs/conf.py) configuration file. This substitution can then be used as a variable in every place where a link to the slack workspace is needed.

After this change, the link to the Label Sleuth's slack workspace should be maintained as follows:
- **Whenever a slack link is needed on a page:**
  - Include the following code: `{{ '[Slack]({})'.format(slack_link) }}`
- **Whenever the value of the slack link needs to be changed:**
  - Edit the values of the following two variables within conf.py:
    - The `slack_link` substitution under `myst_substitutions` 
    - The `url` of the Slack icon under `html_theme_options.icon_links`    