### PR TITLE
Edit meta tags for Twitter and Open Graph

### DIFF
--- a/docs/_templates/index.html
+++ b/docs/_templates/index.html
@@ -10,6 +10,11 @@
    integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js"
    integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Label Sleuth">
+<meta name="twitter:description" content="Open-source no-code system for text annotation and building of text classifiers">
+<meta name="twitter:image" content="https://www.label-sleuth.org/_static/images/opengraph/label-sleuth.png">
+<meta property="og:type" content="website" />
 <meta property="og:title" content="Label Sleuth" />
 <meta property="og:url" content="https://www.label-sleuth.org" />
 <meta property="og:description" content="Open-source no-code system for text annotation and building of text classifiers" />


### PR DESCRIPTION
This PR revises the Open Graph and Twitter meta tags to allow websites that leverage those tags to create nicely formatted previews of the Label Sleuth website, when its link is shared on these services. This PR brings additional improvements on top of https://github.com/label-sleuth/label-sleuth.org/pull/29, which first introduced Open Graph meta tags.