### PR TITLE
Update the instructions to use python 3.9 (additional changes)

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -31,7 +31,7 @@ Recommended procedure to install Label Sleuth:
    In the new terminal, create a Python environment for Label Sleuth: 
 
    ```text
-   conda create --yes -n label-sleuth python=3.8
+   conda create --yes -n label-sleuth python=3.9
    ```
 
    Then, activate the new environment:


### PR DESCRIPTION
Change the installation instructions to use Python 3.9 instead of 3.8, as there are issues with Python 3.8, potentially related to Apple M1 processors. 

This PR changes the installation instructions on the [installation page](https://www.label-sleuth.org/docs/installation.html), augmenting PR https://github.com/label-sleuth/label-sleuth.org/pull/40 (which changed the installation instructions on the [home page](https://www.label-sleuth.org/index.html)). 