### PR TITLE
Bring publications page up to date

### DIFF
--- a/docs/publications.md
+++ b/docs/publications.md
@@ -3,7 +3,7 @@
 This page lists works published by the Label Sleuth core team on system components and related aspects:
 
 **System Description**
-- [Label Sleuth: From Unlabeled Text to a Classifier in a Few Hours](https://arxiv.org/abs/2208.01483) (EMNLP 2022)
+- [Label Sleuth: From Unlabeled Text to a Classifier in a Few Hours](https://aclanthology.org/2022.emnlp-demos.16) (EMNLP 2022)
 
    This is the _main publication_ describing the system. If you use Label Sleuth in your work in any capacity (e.g., for labeling data, extending the system, running experiments, etc.), please cite this paper as follows: 
 
@@ -13,7 +13,7 @@ This page lists works published by the Label Sleuth core team on system componen
       author={Shnarch, Eyal and Halfon, Alon and Gera, Ariel and Danilevsky, Marina and Katsis, Yannis and Choshen, Leshem and Cooper, Martin Santillan and Epelboim, Dina and Zhang, Zheng and Wang, Dakuo and Yip, Lucy and Ein-Dor, Liat and Dankin, Lena and Shnayderman, Ilya and Aharonov, Ranit and Li, Yunyao and Liberman, Naftali and Slesarev, Philip Levin and Newton, Gwilym and Ofek-Koifman, Shila and Slonim, Noam and Katz, Yoav},
       booktitle={Proceedings of the 2022 Conference on Empirical Methods in Natural Language Processing: System Demonstrations},
       publisher = "Association for Computational Linguistics",
-      url={https://arxiv.org/abs/2208.01483},
+      url={https://aclanthology.org/2022.emnlp-demos.16},
       year={2022}
    }
    ```
@@ -22,6 +22,7 @@ This page lists works published by the Label Sleuth core team on system componen
 - [Active Learning for BERT: An Empirical Study](https://aclanthology.org/2020.emnlp-main.638/) (EMNLP 2020)
 - [Facilitating Knowledge Sharing from Domain Experts to Data Scientists for Building NLP Models](https://dl.acm.org/doi/10.1145/3397481.3450637?cid=81474694114) (IUI 2021)
 - [Cluster & Tune: Boost Cold Start Performance in Text Classification](https://aclanthology.org/2022.acl-long.526/) (ACL 2022)
+- [Zero-Shot Text Classification with Self-Training](https://aclanthology.org/2022.emnlp-main.73) (EMNLP 2022)
 
 **Explainability of NLP Models**
 * [Unsupervised Expressive Rules Provide Explainability and Assist Human Experts Grasping New Domains](https://aclanthology.org/2020.findings-emnlp.243/) (Findings of EMNLP 2020)
@@ -32,5 +33,5 @@ This page lists works published by the Label Sleuth core team on system componen
 * [Explainability for Natural Language Processing](https://xainlp.github.io/kddtutorial/) (KDD 2021 Tutorial)
 
 **Evaluation of Interactive ML Systems**
-* [A Simulation-Based Evaluation Framework for Interactive AI Systems and Its Application](https://www.aaai.org/AAAI22Papers/IAAI-00142-HanafiM.pdf) (IAAI 2022)
-* [InteractEva: A Simulation-Based Evaluation Framework for Interactive AI Systems](https://www.aaai.org/AAAI22Papers/DEMO-00309-KatsisY.pdf) (AAAI 2022 Demo)
+* [A Simulation-Based Evaluation Framework for Interactive AI Systems and Its Application](https://ojs.aaai.org/index.php/AAAI/article/view/21541) (IAAI 2022)
+* [InteractEva: A Simulation-Based Evaluation Framework for Interactive AI Systems](https://ojs.aaai.org/index.php/AAAI/article/view/21721) (AAAI 2022 Demo)


### PR DESCRIPTION
This PR updates the publications page to bring it up to date. In particular, it includes the following changes:
- Replace Label Sleuth EMNLP 2022 paper link to arxiv with link to the ACL Anthology, now that the paper appears on the latter
- Add zero-shot EMNLP 2022 paper
- Replace temporary links for the InteractEva AAAI 2022 and IAAI 2022 papers with final links to AAAI proceedings  