### PR TITLE
Bring model and model policies documentation up to date

### DIFF
--- a/docs/docs/dev/model_training.md
+++ b/docs/docs/dev/model_training.md
@@ -62,7 +62,7 @@ Within the codebase, the list of supported models can be found in Label Sleuth's
 
 ### Model policies
 
-The model architecture that is trained in each iteration is prescribed by the employed _model policy_. In its most basic form, a model policy is _static_, resulting in the system always using the same model for every itera  tion. However, model policies can also be _dynamic_, allowing the system to switch between different types of models depending on the iteration. For instance, one can create a model policy instructing Label Sleuth to use a light and fast to train model (such as SVM) for the first few iterations and then switch to more complex and slower to train model (such as BERT) for later iterations. Label Sleuth currently supports the following model policies: 
+The model architecture that is trained in each iteration is prescribed by the employed _model policy_. In its most basic form, a model policy is _static_, resulting in the system always using the same model for every iteration. However, model policies can also be _dynamic_, allowing the system to switch between different types of models depending on the iteration. For instance, one can create a model policy instructing Label Sleuth to use a light and fast to train model (such as SVM) for the first few iterations and then switch to more complex and slower to train model (such as BERT) for later iterations. Label Sleuth currently supports the following model policies: 
 
 | Model policy | Model type | Description |
 |---|---|---|

--- a/docs/docs/dev/model_training.md
+++ b/docs/docs/dev/model_training.md
@@ -49,22 +49,27 @@ Label Sleuth currently includes implementations of the following machine learnin
 | Model name | Description | Implementation details | Hardware requirements
 |---|---|---|---|
 | `NB_OVER_BOW` | Naive Bayes over Bag-of-words | [scikit-learn](https://scikit-learn.org) implementation | - |
-| `NB_OVER_GLOVE` | Naive Bayes over GloVe | - | - |
+| `NB_OVER_WORD_EMBEDDINGS` | Naive Bayes over [word embeddings*](word_embeddings) | - | - |
 | `SVM_OVER_BOW` | Support Vector Machine over Bag-of-words | [scikit-learn](https://scikit-learn.org) implementation  | - |
-| `SVM_OVER_GLOVE` | Support Vector Machine over GloVe | - | - |
-| `SVM_ENSEMBLE` | Ensemble of `SVM_OVER_BOW` and `SVM_OVER_GLOVE` | - | - |
+| `SVM_OVER_WORD_EMBEDDINGS` | Support Vector Machine over [word embeddings*](word_embeddings) | - | - |
+| `SVM_ENSEMBLE` | Ensemble of `SVM_OVER_BOW` and `SVM_OVER_WORD_EMBEDDINGS` | - | - |
 | `HF_BERT` | BERT ([Devlin et al. 2018](https://arxiv.org/abs/1810.04805)) | Pytorch implementation using the [Hugging Face Transformers](https://github.com/huggingface/transformers) library | GPU _(recommended)_ |
 
- Within the codebase, the list of supported models can be found in Label Sleuth's [model catalog](https://github.com/label-sleuth/label-sleuth/blob/main/label_sleuth/models/core/catalog.py). Note that some model may have special hardware requirements to perform as expected (e.g., they require the presence of a GPU).
+Within the codebase, the list of supported models can be found in Label Sleuth's [model catalog](https://github.com/label-sleuth/label-sleuth/blob/main/label_sleuth/models/core/catalog.py). Note that some model may have special hardware requirements to perform as expected (e.g., they require the presence of a GPU).
+
+(word_embeddings)=
+[[*]](word_embeddings) For models that leverage word embeddings, the embeddings come from either [spaCy](https://spacy.io) or [fastText](https://fasttext.cc), depending on the information provided for the particular language (see [languages.py](https://github.com/label-sleuth/label-sleuth/blob/main/label_sleuth/models/core/languages.py) for details).
 
 ### Model policies
 
-The model architecture that is trained in each iteration is prescribed by the employed _model policy_. In its most basic form, a model policy is _static_, resulting in the system always using the same model for every iteration. However, model policies can also be _dynamic_, allowing the system to switch between different types of models depending on the iteration. For instance, one can create a model policy instructing Label Sleuth to use a light and fast to train model (such as SVM) for the first few iterations and then switch to more complex and slower to train model (such as BERT) for later iterations. Label Sleuth currently supports the following model policies: 
+The model architecture that is trained in each iteration is prescribed by the employed _model policy_. In its most basic form, a model policy is _static_, resulting in the system always using the same model for every itera  tion. However, model policies can also be _dynamic_, allowing the system to switch between different types of models depending on the iteration. For instance, one can create a model policy instructing Label Sleuth to use a light and fast to train model (such as SVM) for the first few iterations and then switch to more complex and slower to train model (such as BERT) for later iterations. Label Sleuth currently supports the following model policies: 
 
 | Model policy | Model type | Description |
 |---|---|---|
+| `STATIC_NB_BOW` | Static | Use the `NB_OVER_BOW` model in every iteration |
+| `STATIC_NB_WORD_EMBEDDINGS` | Static | Use the `NB_OVER_WORD_EMBEDDINGS` model in every iteration |
 | `STATIC_SVM_BOW` | Static | Use the `SVM_OVER_BOW` model in every iteration |
-| `STATIC_SVM_GLOVE` | Static | Use the `SVM_OVER_GLOVE` model in every iteration |
+| `STATIC_SVM_WORD_EMBEDDINGS` | Static | Use the `SVM_OVER_WORD_EMBEDDINGS` model in every iteration |
 | `STATIC_SVM_ENSEMBLE`  <br /><defvalue>default</defvalue> | Static | Use the `SVM_ENSEMBLE` model in every iteration |
 | `STATIC_HF_BERT` | Static | Use the `HF_BERT` in every iteration |
 


### PR DESCRIPTION
This PR update the model and model policies documentation to reflect the latest changes to the codebase. These include:

**Models:**
- Replacing in the model table the original `NB_OVER_GLOVE` and `SVM_OVER_GLOVE` constants with the updated `NB_OVER_WORD_EMBEDDINGS` and `SVM_OVER_WORD_EMBEDDINGS` constants, respectively.
- Adding information on the employed word embeddings.

**Model policies:**
- Replacing in the model policies table the original `STATIC_SVM_GLOVE` constant with the updated `STATIC_SVM_WORD_EMBEDDINGS` constant. 
- Adding to the model policies table the recently introduced `STATIC_NB_BOW` and `STATIC_NB_WORD_EMBEDDINGS` model policies.