### PR TITLE
Improve scrollbar styling

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -10,6 +10,28 @@
   --pst-font-family-monospace: 'IBM Plex Mono';
 }
 
+/* Fixes for scrollbar styling; can be removed when we upgrade to at least v0.10.0 of the pydata-sphinx-theme */
+body::-webkit-scrollbar {
+  width: .5rem;
+  height: .5rem;
+}
+
+body::-webkit-scrollbar-thumb {
+  background: #c5c5c5;
+}
+
+body:hover::-webkit-scrollbar-thumb {
+  background: var(--pst-color-text-muted);
+}
+
+body::-webkit-scrollbar-thumb:hover {
+  background: var(--pst-color-text-muted);
+}
+
+body:not(:hover)::-webkit-scrollbar-thumb {
+  visibility: visible;
+}
+
 html[data-theme="light"] {
   --pst-color-primary: #008D36;
   scroll-behavior: smooth;


### PR DESCRIPTION
This PR improves the scrollbar styling to resolve a few issues with the styling employed by the pydata-sphinx-theme version that we currently use. In particular, the PR makes the following improvements:
- Fixes a bug in the theme where the scrollbar disappeared when one hovered over it
- Increases the width of the scrollbar to make it easier to drag
- Makes the scrollbar always visible to improve accessibility

Note that these issues have been fixed beginning with the v0.10.0 update of the pydata-sphinx-theme. Thus, the changes can be removed when we update to a newer version of the theme.